### PR TITLE
chore(release): 3.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.3.1] - 2026-07-27
+
+Hotfix for Nextcloud 34. 3.3.0 is unusable on NC 34 — both the viewer page and every model download return HTTP 500, and the app cannot be upgraded or enabled. Nothing else changed.
+
+### Added
+- **Regression tests for both fatals.** `tests/unit/Service/ResponseBuilderCspTest.php` drives `addCspHeaders()` against a policy double that mirrors the NC 34 API surface with no `__call()` fallback, so it raises the same `Error` production did. `tests/unit/NoPrivateServerApiTest.php` scans `lib/` for any use of the private `\OC` container or the legacy `OC_*` static classes, stripping comments via `token_get_all()` first so documentation *about* a removed API isn't mistaken for a call to it. Both fail on the pre-fix code. Note that `composer test:unit` is not currently run by any CI workflow — `test-integration.yml` runs only `test:integration` and `test:migration` — so these are verified locally until that gap is closed.
+
 ### Changed
 - **`nextcloud/ocp` dev dependency moved from `dev-stable30` to `dev-stable31`**, to match the `min-version="31"` declared in `appinfo/info.xml`; the weekly `update-nextcloud-ocp-matrix.yml` job, which had `target: ['stable30']` hardcoded and kept re-pinning it, now tracks `stable31` too. The pin deliberately follows *min*-version, not max: pinning to the oldest supported server is what stops us using APIs that don't exist there yet, and `ocp` stable33+ requires php `~8.2`, which cannot coexist with the `config.platform` php 8.1 that NC 31 support demands. Verifying against the newest branch is `psalm-matrix.yml`'s job — it already builds an ocp matrix across the full min..max range from `info.xml`. Psalm run manually against stable34 for this release confirms no further removed-API calls in `lib/` beyond the two fixed below, and flags ten `DeprecatedMethod` notices worth scheduling: `IConfig::getUserValue`/`setUserValue`/`deleteUserValue` in `PageController`, `SettingsController` and `ConfigController`, plus `IContainer::query` in `Application`. None break on 34.
 

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -64,7 +64,7 @@
 - ♿ Accessibility features with keyboard navigation and ARIA labels
 
 Built with Three.js for high-performance WebGL rendering. ✨]]></description>
-	<version>3.3.0</version>
+	<version>3.3.1</version>
 	<licence>agpl</licence>
 	<author mail="maz1987in@gmail.com" homepage="https://github.com/maz1987in">Mazin Al Saadi</author>
 	<donation title="Donate to the developers with PayPal" type="paypal">https://www.paypal.com/ncp/payment/KZCB3XTCHGKZC</donation>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "threedviewer",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "threedviewer",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@nextcloud/axios": "^2.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "threedviewer",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "license": "AGPL-3.0-or-later",
   "engines": {
     "node": "^22.0.0",


### PR DESCRIPTION
Hotfix release for Nextcloud 34, closing out #116.

3.3.0 is currently unusable on NC 34 — the viewer page and every model download return HTTP 500, and the app cannot be upgraded or enabled. The app store still serves 3.3.0, so a release is the only thing that reaches affected users.

## Contents

Version bumped to `3.3.1` in `appinfo/info.xml`, `package.json` and `package-lock.json`; the `[Unreleased]` CHANGELOG entries are promoted under a `3.3.1` heading. No functional changes beyond what is already on `main`:

- #117 — the two removed-API fixes (@coverslide, reported with a patch by @EX0l0N)
- #118 — regression tests for both, `nextcloud/ocp` pin corrected to `dev-stable31`

## Verification

The fixes were verified end to end against a real **Nextcloud 34.0.2.1** using this repo's `docker-compose.yml`: the app enables (migrations run), `GET /apps/threedviewer/api/file/<id>` returns 200 with the correct CSP, the viewer page loads, and the log is clean. Reverting either line on the same instance reproduces the reported failures exactly.

`composer install --no-dev --optimize-autoloader --prefer-dist` — the step `release.yml` runs — resolves cleanly on PHP 8.1.


## Known gaps this release does not close

- `composer test:unit` is not run by any workflow, so the new regression tests are not executed by CI.
- 16 jobs use `runs-on: ubuntu-latest-low`, a runner label that does not exist on this repo; `static-psalm-analysis` is skipped on every run.
- `openapi` and `NPM Security Audit` have been failing on every PR independently of this work.
