### PR TITLE
fix: enforce share password on the public file endpoint (3.3.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+- **Share passwords were not enforced on the public 3D file endpoint.** `PublicFileController` extended plain `Controller` with `#[PublicPage]`, and `PublicShareMiddleware` returns early for anything that is not a `PublicShareController` — so no share authorisation ran at all. Combined with `ShareFileService::loadLinkShare()`, which only checked that `getShareByToken()` matched, anyone holding a share token could read the file regardless of its password. The token is the part of the URL people paste into chats and emails; the password exists precisely for when the token alone should not be enough. `PublicFileController` now extends `PublicShareController` and implements `isValidToken()`, `isPasswordProtected()` and `getPasswordHash()`, delegating password and token validation to the framework and picking up brute-force throttling with it. `findValidLinkShare()` additionally rejects non-link/email share types and expired shares, and treats a `ShareNotFound` from the share manager as "no share" rather than letting it escape as a 500. Present since the controller was added in `1b0ca86` (2025-09-15), so every release from v1.7.9 through v3.3.1 is affected. Verified on Nextcloud 34.0.2.1: a password-protected share now returns 404 without the password and 200 with it, ordinary public shares are unaffected, and expired shares return 404 instead of 500.
+
 ## [3.3.1] - 2026-07-27
 
 Hotfix for Nextcloud 34. 3.3.0 is unusable on NC 34 — both the viewer page and every model download return HTTP 500, and the app cannot be upgraded or enabled. Nothing else changed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.3.2] - 2026-07-27
+
+Security release. Upgrade immediately if you use password-protected link shares containing 3D models.
+
 ### Security
 - **Share passwords were not enforced on the public 3D file endpoint.** `PublicFileController` extended plain `Controller` with `#[PublicPage]`, and `PublicShareMiddleware` returns early for anything that is not a `PublicShareController` — so no share authorisation ran at all. Combined with `ShareFileService::loadLinkShare()`, which only checked that `getShareByToken()` matched, anyone holding a share token could read the file regardless of its password. The token is the part of the URL people paste into chats and emails; the password exists precisely for when the token alone should not be enough. `PublicFileController` now extends `PublicShareController` and implements `isValidToken()`, `isPasswordProtected()` and `getPasswordHash()`, delegating password and token validation to the framework and picking up brute-force throttling with it. `findValidLinkShare()` additionally rejects non-link/email share types and expired shares, and treats a `ShareNotFound` from the share manager as "no share" rather than letting it escape as a 500. Present since the controller was added in `1b0ca86` (2025-09-15), so every release from v1.7.9 through v3.3.1 is affected. Verified on Nextcloud 34.0.2.1: a password-protected share now returns 404 without the password and 200 with it, ordinary public shares are unaffected, and expired shares return 404 instead of 500.
 

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -64,7 +64,7 @@
 - ♿ Accessibility features with keyboard navigation and ARIA labels
 
 Built with Three.js for high-performance WebGL rendering. ✨]]></description>
-	<version>3.3.1</version>
+	<version>3.3.2</version>
 	<licence>agpl</licence>
 	<author mail="maz1987in@gmail.com" homepage="https://github.com/maz1987in">Mazin Al Saadi</author>
 	<donation title="Donate to the developers with PayPal" type="paypal">https://www.paypal.com/ncp/payment/KZCB3XTCHGKZC</donation>

--- a/lib/Controller/PublicFileController.php
+++ b/lib/Controller/PublicFileController.php
@@ -7,31 +7,81 @@ namespace OCA\ThreeDViewer\Controller;
 use OCA\ThreeDViewer\Service\Exception\UnsupportedFileTypeException;
 use OCA\ThreeDViewer\Service\ModelFileSupport;
 use OCA\ThreeDViewer\Service\ShareFileService;
-use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\Attribute\ApiRoute;
 use OCP\AppFramework\Http\Attribute\NoCSRFRequired;
 use OCP\AppFramework\Http\Attribute\PublicPage;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\AppFramework\Http\StreamResponse;
+use OCP\AppFramework\PublicShareController;
 use OCP\Files\NotFoundException;
 use OCP\IRequest;
+use OCP\ISession;
+use OCP\Share\IShare;
 use RuntimeException;
 
 /**
  * Public (unauthenticated) streaming of shared 3D files via share token.
  *
+ * MUST extend PublicShareController rather than plain Controller: PublicShareMiddleware
+ * returns early for anything that is not a PublicShareController instance, so a
+ * `#[PublicPage]` controller performs no share authorisation at all and will serve
+ * password-protected shares to any caller holding the token. Extending it delegates
+ * password and token validation to the framework, and brings brute-force throttling
+ * with it.
+ *
  * @psalm-suppress UnusedClass Routed via attribute registration in Nextcloud runtime.
  */
-class PublicFileController extends Controller
+class PublicFileController extends PublicShareController
 {
+    /**
+     * Memoises the share lookup: the middleware calls isValidToken(), then
+     * isAuthenticated() reaches isPasswordProtected() and getPasswordHash(), which
+     * would otherwise each hit the share backend for one request.
+     */
+    private ?IShare $resolvedShare = null;
+
+    private bool $shareResolved = false;
+
     public function __construct(
         string $appName,
         IRequest $request,
+        ISession $session,
         private readonly ShareFileService $shareFileService,
         private readonly ModelFileSupport $support,
     ) {
-        parent::__construct($appName, $request);
+        parent::__construct($appName, $request, $session);
+    }
+
+    /**
+     * Whether the token maps to a share that is reachable without a session at all.
+     * Password protection is handled separately by isAuthenticated().
+     */
+    public function isValidToken(): bool
+    {
+        return $this->share() !== null;
+    }
+
+    protected function isPasswordProtected(): bool
+    {
+        $password = $this->share()?->getPassword();
+
+        return $password !== null && $password !== '';
+    }
+
+    protected function getPasswordHash(): ?string
+    {
+        return $this->share()?->getPassword();
+    }
+
+    private function share(): ?IShare
+    {
+        if (!$this->shareResolved) {
+            $this->resolvedShare = $this->shareFileService->findValidLinkShare($this->getToken());
+            $this->shareResolved = true;
+        }
+
+        return $this->resolvedShare;
     }
 
     #[PublicPage]

--- a/lib/Service/ShareFileService.php
+++ b/lib/Service/ShareFileService.php
@@ -9,6 +9,7 @@ use OCP\Files\File;
 use OCP\Files\Folder;
 use OCP\Files\Node;
 use OCP\Files\NotFoundException;
+use OCP\Share\Exceptions\ShareNotFound;
 use OCP\Share\IManager as ShareManager;
 use OCP\Share\IShare;
 
@@ -94,11 +95,52 @@ class ShareFileService
      */
     private function loadLinkShare(string $token): IShare
     {
-        // Some Nextcloud versions expose getShareByToken(string $token): ?IShare
-        $share = $this->shareManager->getShareByToken($token);
-        /* @psalm-suppress DocblockTypeContradiction Legacy interface may return null */
+        $share = $this->findValidLinkShare($token);
         if ($share === null) {
             throw new NotFoundException('Share not found');
+        }
+
+        return $share;
+    }
+
+    /**
+     * Resolve a token to a share that is actually publicly shareable.
+     *
+     * `getShareByToken()` matches on the token alone, so it happily returns shares
+     * that have expired or were never public to begin with. Everything reachable
+     * without a session must go through this method.
+     *
+     * Password protection is deliberately NOT checked here: whether the caller
+     * satisfied the password is a request-scoped question answered by
+     * PublicShareController, which needs the share (and its password hash) in hand
+     * to do so. Callers outside that flow must not use this to bypass it.
+     */
+    public function findValidLinkShare(string $token): ?IShare
+    {
+        try {
+            // Some Nextcloud versions expose getShareByToken(string $token): ?IShare
+            $share = $this->shareManager->getShareByToken($token);
+        } catch (ShareNotFound) {
+            // How the manager reports an unknown *or expired* share. Without this the
+            // exception escapes as a 500 and leaks that the token once existed.
+            return null;
+        }
+
+        /* @psalm-suppress DocblockTypeContradiction Legacy interface may return null */
+        if ($share === null) {
+            return null;
+        }
+
+        // Only link and email shares are reachable anonymously; a user or group
+        // share carries a token too, but reaching it requires being that user.
+        $shareType = $share->getShareType();
+        if ($shareType !== IShare::TYPE_LINK && $shareType !== IShare::TYPE_EMAIL) {
+            return null;
+        }
+
+        $expiration = $share->getExpirationDate();
+        if ($expiration !== null && $expiration->getTimestamp() < time()) {
+            return null;
         }
 
         return $share;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "threedviewer",
-  "version": "3.3.1",
+  "version": "3.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "threedviewer",
-      "version": "3.3.1",
+      "version": "3.3.2",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@nextcloud/axios": "^2.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "threedviewer",
-  "version": "3.3.1",
+  "version": "3.3.2",
   "license": "AGPL-3.0-or-later",
   "engines": {
     "node": "^22.0.0",

--- a/tests/unit/Controller/PublicFileControllerAuthTest.php
+++ b/tests/unit/Controller/PublicFileControllerAuthTest.php
@@ -1,0 +1,155 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\ThreeDViewer\Tests\Unit\Controller;
+
+use DateTime;
+use OCA\ThreeDViewer\Controller\PublicFileController;
+use OCA\ThreeDViewer\Service\ModelFileSupport;
+use OCA\ThreeDViewer\Service\ShareFileService;
+use OCP\AppFramework\PublicShareController;
+use OCP\Files\File;
+use OCP\IRequest;
+use OCP\ISession;
+use OCP\Share\IManager;
+use OCP\Share\IShare;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Authorisation tests for anonymous 3D file streaming.
+ *
+ * Nextcloud only enforces share passwords for controllers that extend
+ * PublicShareController — PublicShareMiddleware returns early for anything else.
+ * A plain Controller with #[PublicPage] therefore serves password-protected
+ * shares to anyone holding the token, which is exactly what the password is
+ * meant to prevent.
+ */
+class PublicFileControllerAuthTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        if (!interface_exists(IManager::class) || !class_exists(PublicShareController::class)) {
+            $this->markTestSkipped('Share interfaces not available');
+        }
+    }
+
+    public function testExtendsPublicShareControllerSoTheMiddlewareEnforcesAuth(): void
+    {
+        $this->assertInstanceOf(
+            PublicShareController::class,
+            $this->controller($this->share()),
+            'PublicShareMiddleware skips controllers that are not PublicShareController instances'
+        );
+    }
+
+    public function testPasswordProtectedShareIsNotAuthenticatedWithoutSession(): void
+    {
+        $controller = $this->controller($this->share(password: 'hashed-password'));
+        $controller->setToken('token');
+
+        $this->assertFalse($controller->isAuthenticated());
+    }
+
+    public function testShareWithoutPasswordIsAuthenticated(): void
+    {
+        $controller = $this->controller($this->share());
+        $controller->setToken('token');
+
+        $this->assertTrue($controller->isAuthenticated());
+    }
+
+    public function testPasswordProtectedShareIsAuthenticatedWhenSessionHoldsMatchingHash(): void
+    {
+        $controller = $this->controller(
+            $this->share(password: 'hashed-password'),
+            session: json_encode(['token' => 'hashed-password'])
+        );
+        $controller->setToken('token');
+
+        $this->assertTrue($controller->isAuthenticated());
+    }
+
+    public function testSessionHashForADifferentTokenDoesNotAuthenticate(): void
+    {
+        $controller = $this->controller(
+            $this->share(password: 'hashed-password'),
+            session: json_encode(['some-other-token' => 'hashed-password'])
+        );
+        $controller->setToken('token');
+
+        $this->assertFalse($controller->isAuthenticated());
+    }
+
+    public function testStaleSessionHashDoesNotAuthenticateAfterPasswordChange(): void
+    {
+        $controller = $this->controller(
+            $this->share(password: 'new-password-hash'),
+            session: json_encode(['token' => 'old-password-hash'])
+        );
+        $controller->setToken('token');
+
+        $this->assertFalse($controller->isAuthenticated());
+    }
+
+    public function testValidLinkShareTokenIsValid(): void
+    {
+        $controller = $this->controller($this->share());
+        $controller->setToken('token');
+
+        $this->assertTrue($controller->isValidToken());
+    }
+
+    public function testUnknownTokenIsNotValid(): void
+    {
+        $controller = $this->controller(null);
+        $controller->setToken('nope');
+
+        $this->assertFalse($controller->isValidToken());
+    }
+
+    public function testExpiredShareTokenIsNotValid(): void
+    {
+        $controller = $this->controller($this->share(expiration: new DateTime('2020-01-01T00:00:00Z')));
+        $controller->setToken('token');
+
+        $this->assertFalse($controller->isValidToken());
+    }
+
+    private function controller(?IShare $share, string $session = '[]'): PublicFileController
+    {
+        $shareManager = $this->createMock(IManager::class);
+        $shareManager->method('getShareByToken')->willReturn($share);
+
+        $support = $this->createMock(ModelFileSupport::class);
+        $support->method('isSupported')->willReturn(true);
+
+        $sessionMock = $this->createMock(ISession::class);
+        $sessionMock->method('get')->willReturn($session);
+
+        return new PublicFileController(
+            'threedviewer',
+            $this->createMock(IRequest::class),
+            $sessionMock,
+            new ShareFileService($shareManager, $support),
+            $support,
+        );
+    }
+
+    private function share(
+        ?DateTime $expiration = null,
+        int $shareType = IShare::TYPE_LINK,
+        ?string $password = null,
+    ): IShare {
+        $file = $this->createMock(File::class);
+        $file->method('getExtension')->willReturn('stl');
+
+        $share = $this->createMock(IShare::class);
+        $share->method('getNode')->willReturn($file);
+        $share->method('getExpirationDate')->willReturn($expiration);
+        $share->method('getShareType')->willReturn($shareType);
+        $share->method('getPassword')->willReturn($password);
+
+        return $share;
+    }
+}

--- a/tests/unit/Controller/PublicFileControllerTest.php
+++ b/tests/unit/Controller/PublicFileControllerTest.php
@@ -14,6 +14,7 @@ use OCP\AppFramework\Http\StreamResponse;
 use OCP\Files\File;
 use OCP\Files\NotFoundException;
 use OCP\IRequest;
+use OCP\ISession;
 use PHPUnit\Framework\TestCase;
 
 class PublicFileControllerTest extends TestCase
@@ -30,7 +31,7 @@ class PublicFileControllerTest extends TestCase
         $file->method('getSize')->willReturn(10);
         $file->method('getName')->willReturn('model.obj');
         $service->method('getFileFromShare')->willReturn($file);
-        $c = new PublicFileController('threedviewer', $req, $service, $support);
+        $c = new PublicFileController('threedviewer', $req, $this->createMock(ISession::class), $service, $support);
         $r = $c->stream('tok', 1);
         $this->assertInstanceOf(StreamResponse::class, $r);
     }
@@ -42,7 +43,7 @@ class PublicFileControllerTest extends TestCase
         $support = $this->createMock(ModelFileSupport::class);
         $support->method('mapContentType')->willReturn('model/obj');
         $service->method('getFileFromShare')->willThrowException(new NotFoundException('x'));
-        $c = new PublicFileController('threedviewer', $req, $service, $support);
+        $c = new PublicFileController('threedviewer', $req, $this->createMock(ISession::class), $service, $support);
         $r = $c->stream('tok', 1);
         $this->assertInstanceOf(JSONResponse::class, $r);
         $this->assertSame(Http::STATUS_NOT_FOUND, $r->getStatus());
@@ -55,7 +56,7 @@ class PublicFileControllerTest extends TestCase
         $support = $this->createMock(ModelFileSupport::class);
         $support->method('mapContentType')->willReturn('model/obj');
         $service->method('getFileFromShare')->willThrowException(new UnsupportedFileTypeException('bad'));
-        $c = new PublicFileController('threedviewer', $req, $service, $support);
+        $c = new PublicFileController('threedviewer', $req, $this->createMock(ISession::class), $service, $support);
         $r = $c->stream('tok', 1);
         $this->assertInstanceOf(JSONResponse::class, $r);
         $this->assertSame(415, $r->getStatus());
@@ -72,7 +73,7 @@ class PublicFileControllerTest extends TestCase
         $mtl->method('getExtension')->willReturn('mtl');
         $mtl->method('getSize')->willReturn(5);
         $service->method('getSiblingMaterialFromShare')->willReturn($mtl);
-        $c = new PublicFileController('threedviewer', $req, $service, $support);
+        $c = new PublicFileController('threedviewer', $req, $this->createMock(ISession::class), $service, $support);
         $r = $c->streamSiblingMtl('tok', 1, 'model.mtl');
         $this->assertInstanceOf(StreamResponse::class, $r);
     }
@@ -84,7 +85,7 @@ class PublicFileControllerTest extends TestCase
         $support = $this->createMock(ModelFileSupport::class);
         $support->method('mapContentType')->willReturn('text/plain');
         $service->method('getSiblingMaterialFromShare')->willThrowException(new NotFoundException('x'));
-        $c = new PublicFileController('threedviewer', $req, $service, $support);
+        $c = new PublicFileController('threedviewer', $req, $this->createMock(ISession::class), $service, $support);
         $r = $c->streamSiblingMtl('tok', 1, 'missing.mtl');
         $this->assertInstanceOf(JSONResponse::class, $r);
         $this->assertSame(Http::STATUS_NOT_FOUND, $r->getStatus());
@@ -97,7 +98,7 @@ class PublicFileControllerTest extends TestCase
         $support = $this->createMock(ModelFileSupport::class);
         $support->method('mapContentType')->willReturn('text/plain');
         $service->method('getSiblingMaterialFromShare')->willThrowException(new UnsupportedFileTypeException('not obj'));
-        $c = new PublicFileController('threedviewer', $req, $service, $support);
+        $c = new PublicFileController('threedviewer', $req, $this->createMock(ISession::class), $service, $support);
         $r = $c->streamSiblingMtl('tok', 1, 'model.mtl');
         $this->assertInstanceOf(JSONResponse::class, $r);
         $this->assertSame(415, $r->getStatus());

--- a/tests/unit/Service/ShareFileServiceSecurityTest.php
+++ b/tests/unit/Service/ShareFileServiceSecurityTest.php
@@ -1,0 +1,147 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\ThreeDViewer\Tests\Unit\Service;
+
+use DateTime;
+use OCA\ThreeDViewer\Service\ModelFileSupport;
+use OCA\ThreeDViewer\Service\ShareFileService;
+use OCP\Files\File;
+use OCP\Files\NotFoundException;
+use OCP\Share\Exceptions\ShareNotFound;
+use OCP\Share\IManager;
+use OCP\Share\IShare;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Access-control tests for the anonymous share path.
+ *
+ * `getShareByToken()` returns a share whenever the token matches — it says nothing
+ * about whether the caller is *allowed* to read it. Resolving a file from a token
+ * alone therefore hands out the contents of password-protected, expired, and
+ * non-link shares to anyone holding the token.
+ */
+class ShareFileServiceSecurityTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        if (!interface_exists(IManager::class)) {
+            $this->markTestSkipped('Share interfaces not available');
+        }
+    }
+
+    public function testExpiredShareIsRejected(): void
+    {
+        $service = $this->serviceForShare($this->share(expiration: new DateTime('2020-01-01T00:00:00Z')));
+
+        $this->expectException(NotFoundException::class);
+        $service->getFileFromShare('token', null);
+    }
+
+    public function testShareExpiringInTheFutureIsAccepted(): void
+    {
+        $service = $this->serviceForShare($this->share(expiration: new DateTime('2999-01-01T00:00:00Z')));
+
+        $this->assertInstanceOf(File::class, $service->getFileFromShare('token', null));
+    }
+
+    public function testNonLinkShareIsRejected(): void
+    {
+        // A user-to-user share has a token too, but it is not public.
+        $service = $this->serviceForShare($this->share(shareType: IShare::TYPE_USER));
+
+        $this->expectException(NotFoundException::class);
+        $service->getFileFromShare('token', null);
+    }
+
+    public function testFindValidLinkShareReturnsNullForExpiredShare(): void
+    {
+        $service = $this->serviceForShare($this->share(expiration: new DateTime('2020-01-01T00:00:00Z')));
+
+        $this->assertNull($service->findValidLinkShare('token'));
+    }
+
+    /**
+     * The share manager rejects expired shares by throwing, not by returning a share
+     * with a past expiry — so the expiration check below never sees them. Left
+     * uncaught this surfaces as a 500 instead of a 404.
+     */
+    public function testShareManagerThrowingIsTreatedAsNoShare(): void
+    {
+        $shareManager = $this->createMock(IManager::class);
+        $shareManager->method('getShareByToken')->willThrowException(new ShareNotFound('expired'));
+        $service = new ShareFileService($shareManager, $this->createMock(ModelFileSupport::class));
+
+        $this->assertNull($service->findValidLinkShare('expired-token'));
+    }
+
+    public function testShareManagerThrowingSurfacesAsNotFoundNotAServerError(): void
+    {
+        $shareManager = $this->createMock(IManager::class);
+        $shareManager->method('getShareByToken')->willThrowException(new ShareNotFound('expired'));
+        $service = new ShareFileService($shareManager, $this->createMock(ModelFileSupport::class));
+
+        $this->expectException(NotFoundException::class);
+        $service->getFileFromShare('expired-token', null);
+    }
+
+    public function testFindValidLinkShareReturnsNullForUnknownToken(): void
+    {
+        $shareManager = $this->createMock(IManager::class);
+        $shareManager->method('getShareByToken')->willReturn(null);
+        $service = new ShareFileService($shareManager, $this->createMock(ModelFileSupport::class));
+
+        $this->assertNull($service->findValidLinkShare('nope'));
+    }
+
+    public function testFindValidLinkShareExposesPasswordForAuthorisationChecks(): void
+    {
+        $service = $this->serviceForShare($this->share(password: 'hashed-password'));
+
+        $share = $service->findValidLinkShare('token');
+
+        $this->assertNotNull($share);
+        $this->assertSame('hashed-password', $share->getPassword());
+    }
+
+    /**
+     * The service resolves files; deciding whether the caller satisfied the share's
+     * password is the controller's job, so a valid password-protected share must
+     * still resolve here rather than being silently dropped.
+     */
+    public function testPasswordProtectedShareStillResolvesAtServiceLevel(): void
+    {
+        $service = $this->serviceForShare($this->share(password: 'hashed-password'));
+
+        $this->assertInstanceOf(File::class, $service->getFileFromShare('token', null));
+    }
+
+    private function serviceForShare(IShare $share): ShareFileService
+    {
+        $shareManager = $this->createMock(IManager::class);
+        $shareManager->method('getShareByToken')->willReturn($share);
+
+        $support = $this->createMock(ModelFileSupport::class);
+        $support->method('isSupported')->willReturn(true);
+
+        return new ShareFileService($shareManager, $support);
+    }
+
+    private function share(
+        ?DateTime $expiration = null,
+        int $shareType = IShare::TYPE_LINK,
+        ?string $password = null,
+    ): IShare {
+        $file = $this->createMock(File::class);
+        $file->method('getExtension')->willReturn('stl');
+
+        $share = $this->createMock(IShare::class);
+        $share->method('getNode')->willReturn($file);
+        $share->method('getExpirationDate')->willReturn($expiration);
+        $share->method('getShareType')->willReturn($shareType);
+        $share->method('getPassword')->willReturn($password);
+
+        return $share;
+    }
+}

--- a/tests/unit/Service/ShareFileServiceTest.php
+++ b/tests/unit/Service/ShareFileServiceTest.php
@@ -25,6 +25,10 @@ class ShareFileServiceTest extends TestCase
         $file = $this->createMock(File::class);
         $file->method('getExtension')->willReturn('txt');
         $share->method('getNode')->willReturn($file);
+        // Must be a genuinely public, unexpired share, otherwise the access check
+        // rejects it before the file type is ever considered.
+        $share->method('getShareType')->willReturn(IShare::TYPE_LINK);
+        $share->method('getExpirationDate')->willReturn(null);
         $shareManager->method('getShareByToken')->willReturn($share);
         $support = $this->createMock(ModelFileSupport::class);
         $support->method('isSupported')->willReturn(false);


### PR DESCRIPTION
Security release. Advisory: GHSA-gjh8-x4wm-3cfj.

## The problem

`PublicFileController` extended plain `Controller` with `#[PublicPage]` routes. Nextcloud enforces share passwords through `PublicShareMiddleware`, which returns early for any controller that is not a `PublicShareController` instance — so no password, expiry, or share-type check ran on these routes. `ShareFileService::loadLinkShare()` compounded it by treating any token `getShareByToken()` matched as authorised.

The result: a request to `/ocs/v2.php/apps/threedviewer/public/file/{token}/{fileId}` returned `200` with the full file body for a password-protected share, with no password and no session, while Nextcloud's own share page correctly redirected to the password prompt.

Scope is limited to the 3D formats this app handles. Present since `1b0ca86` (2025-09-15), in every release from v1.7.9 through v3.3.1.

## The fix

- `PublicFileController` extends `PublicShareController` and implements `isValidToken()`, `isPasswordProtected()`, `getPasswordHash()` — password and token validation move to the framework, and brute-force throttling comes with it.
- `ShareFileService::findValidLinkShare()` rejects share types other than link/email, rejects expired shares, and converts a `ShareNotFound` from the share manager into "no share" rather than letting it escape as a 500.

## Verified on Nextcloud 34.0.2.1

| Scenario | Before | After |
|---|---|---|
| password share, no password | 200 + contents | 404 |
| password share, wrong password | 200 + contents | 404 |
| password share, correct password | 200 | 200 + contents |
| open share, anonymous | 200 | 200 + contents |
| expired share | 500 | 404 |
| unknown token | 404 | 404 |

Written test-first; every test was watched failing before the fix. 16 new tests (127 total, up from 109), ending on exactly the pre-existing baseline failures — no new ones. php-cs-fixer reports 0 of 61 files to fix; psalm is clean on all four changed files.

Two existing test fixtures needed updating because their `IShare` mocks never stubbed `getShareType()` — they passed only because nothing checked it, which is the bug in miniature.