### PR TITLE
Drop the dead generateUrl import

### DIFF
--- a/src/composables/useModelLoading.js
+++ b/src/composables/useModelLoading.js
@@ -5,7 +5,6 @@
 
 import { ref, shallowRef, computed, markRaw } from 'vue'
 import * as THREE from 'three'
-import { generateUrl } from '@nextcloud/router'
 import { loadModelByExtension, isSupportedExtension } from '../loaders/registry.js'
 import { loadModelWithDependencies } from '../loaders/multiFileHelpers.js'
 import { buildFileUrl } from './usePublicShare.js'


### PR DESCRIPTION
`main` is red on **Lint eslint**:

```
src/composables/useModelLoading.js
  8:10  error  'generateUrl' is defined but never used  no-unused-vars
```

#123 replaced the `generateUrl()` call with `buildFileUrl()`, which picks the public-token endpoint on a share page, but left the import behind. `no-unused-vars` is an error in this project's eslint config, so the whole job fails.

The import is genuinely dead — `buildFileUrl(fileId)` at line 239 is the only URL builder the file uses now. Nothing was lost in the merge.

## Why this reached `main`

The `Lint eslint` run on #123 never completed. It sat at `status=pending`, and an incomplete workflow run contributes **no check** to the pull request — so `gh pr checks` reported `0 pending` rather than one outstanding.

Absent checks read as satisfied. #123 showed 16 passing checks against #128's 43, and the gap was the JavaScript jobs: eslint, Jest, build, and Node. The same is true of #122, #124 and #126, whose eslint runs are also still `pending`:

```
feat/public-share-viewer       status=pending
fix/viewer-controller-ui       status=pending
fix/three-shadow-deprecation   status=pending
chore/stylelint-17             status=pending
```

Only `Lint eslint` is failing on `main`; the other twelve workflows all pass, so this is the only escape.

Anything gating on CI should compare against the set of checks it expects rather than trusting an empty pending list, or read `statusCheckRollup`, which includes queued runs.

## Verification

eslint drops from 1 error to 0 (259 warnings unchanged, all pre-existing). Jest 88/88, build clean, all bundles within budget.