### PR TITLE
test: pin case-sensitive folder listing across all supported databases

### DIFF
--- a/tests/integration/FileIndexMapperTest.php
+++ b/tests/integration/FileIndexMapperTest.php
@@ -92,6 +92,34 @@ class FileIndexMapperTest extends TestCase
         $this->assertSame(['a_b/child'], $folders);
     }
 
+    /**
+     * Two folders differing only in case can both exist, because Nextcloud storage is
+     * case-sensitive. Which of them a listing belongs to must not depend on how the
+     * database compares strings.
+     *
+     * It currently does not, on any supported backend — but not for a reason visible
+     * here. The descendant query is a LIKE, and MySQL's *server* default collation is
+     * `utf8mb4_0900_ai_ci`, under which `LIKE 'Models/%'` also matches `models/beta`.
+     * What keeps that from happening is `ConnectionFactory`, which creates every
+     * Nextcloud table `utf8_bin` (`utf8mb4_bin` with `mysql.utf8mb4`). The binary
+     * collation is the whole guarantee.
+     *
+     * So this pins an invariant that rests on a server setting rather than on anything
+     * in this app: were the collation ever to drift, the extra row would fail the prefix
+     * strip in extractImmediateChildren(), its first segment would be taken whole, and
+     * the browser would offer `Models/models` — a folder nobody has, the same shape as
+     * the `modelstextures` defect above.
+     */
+    public function testDoesNotListAChildOfADifferentlyCasedSibling(): void
+    {
+        $this->index('Models/alpha', 'one.obj');
+        $this->index('models/beta', 'two.obj');
+
+        $folders = $this->mapper->getFolders($this->userId, 'Models');
+
+        $this->assertSame(['Models/alpha'], $folders);
+    }
+
     public function testFindsFilesByFolderThroughTheHashedPath(): void
     {
         $this->index('models', 'chair.obj');


### PR DESCRIPTION
**The bug this started out to fix does not exist.** Recording that, and what the branch is now.

## The hypothesis, and why it was wrong

`getFolders()` finds descendants with a LIKE. MySQL's *server* default collation is `utf8mb4_0900_ai_ci`, under which `LIKE 'Models/%'` also matches `models/beta` — I confirmed that against a stock MySQL container. The extra row would then fail the prefix strip in `extractImmediateChildren()`, its first segment would be taken whole, and the file browser would offer `Models/models`: a folder nobody has, the same shape as the `modelstextures` defect already covered here.

The prediction was that `integration mysql` would fail. It passed.

The reason is `ConnectionFactory`, which sets `defaultTableOptions.collate` to `utf8_bin`, or `utf8mb4_bin` when `mysql.utf8mb4` is set. Every Nextcloud table is created with a binary collation, so LIKE is case-sensitive there regardless of the server default. Re-probing with both collations side by side:

| table collation | `LIKE 'Models/%'` returns |
| --- | --- |
| server default (`utf8mb4_0900_ai_ci`) | `Models/alpha`, `models/beta` |
| `utf8mb4_bin` (what Nextcloud creates) | `Models/alpha` |

The first probe used a table created with the server default — a table Nextcloud never creates. The conclusion was drawn from the wrong object.

## What is left

The test, as a characterisation test. It passes on SQLite, MySQL and PostgreSQL today, and its value is that the invariant is now asserted somewhere: the guarantee lives in a server-side table option, not in this app, and nothing else here records that it is being relied on. If the collation ever drifts, the browser starts inventing folders and this says so.

A guard in `extractImmediateChildren()` was written and dropped. It defended a state that cannot currently occur, and code for an unreachable branch is not an improvement — the existing fallback is equally unreachable.

## Note on the database axis

This is the first question [#139](https://github.com/maz1987in/3Dviewer-Nextcloud/pull/139)'s MySQL and PostgreSQL jobs were asked, and they answered it correctly by refusing to confirm a plausible bug. Disproving a hypothesis is the same mechanism as catching a regression.
