### PR TITLE
chore(release): 3.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.4.0] - 2026-07-28
+
+Public share links now render 3D models, and every format that carries external textures resolves them there. Also carries the security fixes listed below.
+
 ### Added
 - **A merge gate that treats an absent check as a failure**, as a ruleset on `main` and as `npm run pr:ready`. `gh pr checks` reports only the checks that exist, so a queued run contributes none and a pull request whose matrix has not started looks exactly like one where everything passed — which is how a broken eslint run reached `main`. The required set is the seven summary jobs: each aggregates its own matrix and reports unconditionally. Because the ruleset also covers pushes, work on `main` now goes through a pull request.
 - **The integration suite now also runs on MySQL and PostgreSQL.** The version axis is covered on SQLite; this adds the database axis, which is where the queries differ rather than where the server does — `escapeLikeParameter()` picks an escape character per platform, and MySQL's default collation is case-insensitive where SQLite's and PostgreSQL's are not, so a folder listing settled on one backend is not settled on the others. Newest supported server only, rather than crossing both axes.

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -64,7 +64,7 @@
 - ♿ Accessibility features with keyboard navigation and ARIA labels
 
 Built with Three.js for high-performance WebGL rendering. ✨]]></description>
-	<version>3.3.2</version>
+	<version>3.4.0</version>
 	<licence>agpl</licence>
 	<author mail="maz1987in@gmail.com" homepage="https://github.com/maz1987in">Mazin Al Saadi</author>
 	<namespace>ThreeDViewer</namespace>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "threedviewer",
-  "version": "3.3.2",
+  "version": "3.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "threedviewer",
-      "version": "3.3.2",
+      "version": "3.4.0",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@nextcloud/axios": "^2.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "threedviewer",
-  "version": "3.3.2",
+  "version": "3.4.0",
   "license": "AGPL-3.0-or-later",
   "engines": {
     "node": "^22.0.0",


### PR DESCRIPTION
Cuts 3.4.0 from the 31 accumulated `Unreleased` entries, spanning 24 commits since v3.3.2.

## Why minor rather than patch

Public share links render 3D models at all, which they did not before ([#115](https://github.com/maz1987in/3Dviewer-Nextcloud/issues/115)), and every format that carries external textures now resolves them there — OBJ, glTF, COLLADA, X3D, FBX and 3DS. New capability rather than corrected behaviour.

## What is in it

**Public shares.** Share pages previously rendered nothing for anonymous visitors. They now load the viewer, and dependencies resolve by declaration through a token-keyed route where the model's own references are the authorisation — an undeclared name is refused, as is any path escaping the model's folder.

**Case handling.** A dependency whose declared case differs from the file on disk now resolves, on the public route and for signed-in sessions alike, through one shared implementation. 3DS map names are DOS 8.3 and MTL files authored on Windows name directories in mixed case, so this was the ordinary case rather than a corner of it.

**Testing.** A PHP integration suite that runs against a real Nextcloud server, across the supported version range on SQLite and against MySQL and PostgreSQL on the newest. It has already caught defects the mocked unit suite structurally could not.

**Security.** Four npm advisories resolved in production dependencies, and a cap on material libraries per model so that one crafted OBJ cannot turn each dependency request on its share into hundreds of thousands of storage lookups.

## Residual, shipping knowingly

The changelog records one unresolved item: the shipped browser chunk still carries an unpatched `brace-expansion`, because Vite resolves `webdav` to a prebuilt bundle with it inlined. It cannot be reached by `npm audit fix` and is documented rather than silently carried.

## Files

Version bumped in `appinfo/info.xml`, `package.json` and the lockfile — the three places the release workflow and the app store read. All three verified consistent.

## Note on what happens next

This pull request publishes nothing. Tagging `v3.4.0` afterwards is what triggers `release.yml`, which builds the artifact, creates the GitHub release, and pushes to the public Nextcloud App Store.

That last step carries `continue-on-error: true`, so a failed store publish still leaves the workflow green. A green release run is not by itself evidence that the app store received the build; the store listing has to be checked directly.
