### PR TITLE
fix(viewer): let the antialiasing setting reach the renderer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - ESLint moved to flat config, for `@nextcloud/eslint-config` v9. New rule families are off and newly-promoted rules are warnings, each carrying its count in the config.
 
 ### Fixed
+- The antialiasing setting did nothing — the renderer hardcoded it on. It now follows the setting, applied at mount.
 - The help dialog dimmed the viewer and left the rest of the page lit. The four fixed overlays are teleported to the body, past the containing block Nextcloud's `backdrop-filter` creates.
 - The help panel drew different icons from the controls it describes; eight rows disagreed.
 - The controller rail's full-width controls sat seventeen pixels left of centre.

--- a/src/components/ThreeViewer.vue
+++ b/src/components/ThreeViewer.vue
@@ -1042,7 +1042,9 @@ export default {
 
 				// Create renderer
 				renderer.value = markRaw(new THREE.WebGLRenderer({
-					antialias: true,
+					// Only settable when the context is created, so this follows the
+					// setting at mount; changing it takes effect on the next load.
+					antialias: props.enableAntialiasing,
 					alpha: true,
 					powerPreference: 'high-performance',
 					preserveDrawingBuffer: true, // Required for screenshots

--- a/tests/unit/antialiasingSetting.test.js
+++ b/tests/unit/antialiasingSetting.test.js
@@ -1,0 +1,78 @@
+/**
+ * The MSAA setting has to reach the renderer that implements it.
+ *
+ * `enableAntialiasing` is offered in Personal Settings, defaulted in
+ * `viewer-config.js`, restored from saved settings by `App.vue`, bound onto
+ * `<ThreeViewer>` as `:enable-antialiasing`, and declared there as a prop —
+ * five places, none of which is the one that matters. `WebGLRenderer` was
+ * constructed with a hardcoded `antialias: true`, so the toggle persisted a
+ * value nothing ever read: turning it off changed the stored settings, the
+ * checkbox and nothing else.
+ *
+ * Vue reports none of this. A declared prop that no expression mentions is
+ * simply never read, and a control wired to it looks correct at every point
+ * along the chain.
+ *
+ * Checked by reading the source: `antialias` can only be set when the context
+ * is created, so the assertion is about how `WebGLRenderer` is constructed, and
+ * jsdom has no WebGL context to construct one against.
+ */
+const { readFileSync } = require('fs')
+const { join } = require('path')
+const { parse } = require('@vue/compiler-sfc')
+
+const VIEWER = join(__dirname, '..', '..', 'src', 'components', 'ThreeViewer.vue')
+
+/**
+ * The component's script, with comments blanked so that a note *about* a prop
+ * does not read as a use of it.
+ *
+ * @return {string} script content, comments replaced by equivalent whitespace
+ */
+function scriptWithoutComments() {
+	const { descriptor } = parse(readFileSync(VIEWER, 'utf8'))
+	const script = (descriptor.script?.content ?? '') + '\n' + (descriptor.scriptSetup?.content ?? '')
+	return script.replace(/\/\*[\s\S]*?\*\/|\/\/[^\n]*/g, (m) => m.replace(/[^\n]/g, ' '))
+}
+
+/**
+ * The option object passed to `new THREE.WebGLRenderer({ … })`.
+ *
+ * @param {string} script - component script
+ * @return {string} the text between the constructor's braces
+ */
+function rendererOptions(script) {
+	const at = script.indexOf('new THREE.WebGLRenderer(')
+	expect(at).toBeGreaterThan(-1)
+	const open = script.indexOf('{', at)
+	let depth = 0
+	for (let i = open; i < script.length; i++) {
+		if (script[i] === '{') depth++
+		else if (script[i] === '}') {
+			depth--
+			if (depth === 0) return script.slice(open + 1, i)
+		}
+	}
+	throw new Error('unterminated WebGLRenderer options')
+}
+
+describe('the antialiasing setting', () => {
+	it('is read by the component that declares it', () => {
+		const script = scriptWithoutComments()
+		const declaration = /enableAntialiasing\s*:\s*\{/.exec(script)
+
+		expect(declaration).not.toBeNull()
+
+		const elsewhere = script.slice(0, declaration.index)
+			+ script.slice(declaration.index + declaration[0].length)
+
+		expect(elsewhere).toMatch(/\benableAntialiasing\b/)
+	})
+
+	it('decides how the renderer is constructed', () => {
+		const options = rendererOptions(scriptWithoutComments())
+
+		expect(options).toMatch(/antialias\s*:/)
+		expect(options).not.toMatch(/antialias\s*:\s*(true|false)\s*[,}]/)
+	})
+})


### PR DESCRIPTION
The MSAA toggle in Personal Settings did nothing.

`enableAntialiasing` exists in five places:

```
PersonalSettings  →  viewer-config.js  →  App.vue restores it from saved settings
                  →  :enable-antialiasing on <ThreeViewer>  →  declared as a prop
                                                                      ↓
                              new THREE.WebGLRenderer({ antialias: true })
```

The renderer hardcoded it. So the prop was declared and never read: turning MSAA off changed the stored settings, changed the checkbox, and changed nothing about what was drawn.

Vue reports none of this — a declared prop that no expression mentions is simply never read — so every point along the chain reads correctly in isolation.

## The fix, and its limit

The renderer now takes the setting. `antialias` can only be chosen when the WebGL context is created, so it applies at mount and a change lands on the next load rather than instantly. Forcing a remount would drop the context and reload the model to apply a checkbox; the constraint is documented at the call site.

## Test

Checked by reading the source, for the same reason `shadowMapType.test.js` does: jsdom has no WebGL context to build a renderer against. Two assertions — the prop is read somewhere other than its own declaration, and the renderer's `antialias` is not a literal. Both fail on the previous code:

```
Expected pattern: not /antialias\s*:\s*(true|false)\s*[,}]/
Received string:  "antialias: true, alpha: true, …"
```

Comments are blanked before scanning, so a note *about* the prop cannot read as a use of it.

## Three more of these

A sweep of every component for props that are declared and never read turned up three others, left for separate work because they need behaviour checks rather than a one-line fix:

- `FileNavigation.vue:77` and `FileNavigation/TypeItem.vue:34` both declare `selectedFileId` and never read it, while sibling components use exactly that prop to paint the `selected` class (`FileItem.vue:6`, `FileBrowser.vue:235`). Likely a missing selection highlight in those navigation modes rather than dead code.
- `ViewerModal.vue:63` declares `attr`, which nothing passes and nothing reads.

Stacked on #152; retargets to `main` when that merges.
