### PR TITLE
chore(release): 3.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.5.0] - 2026-08-11
+
+The viewer is redrawn on a themeable design system: the Theme control now moves the whole viewer rather than only the scene, every control is a Material Design icon instead of an emoji, and the top bar, tools panel, slicer dialog, performance HUD and the measurement and annotation surfaces follow the design sheet. Also carries three.js r185, the move to ESLint flat config, and the security fixes listed below.
+
 ### Added
 - Keyboard shortcuts for six tool rows: `R` reset view, `F` fit to view, `M` measurement, `S` statistics, `P` screenshot, `?` help.
 - The Playwright suite now runs in CI.

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -64,7 +64,7 @@
 - ♿ Accessibility features with keyboard navigation and ARIA labels
 
 Built with Three.js for high-performance WebGL rendering. ✨]]></description>
-	<version>3.4.0</version>
+	<version>3.5.0</version>
 	<licence>agpl</licence>
 	<author mail="maz1987in@gmail.com" homepage="https://github.com/maz1987in">Mazin Al Saadi</author>
 	<namespace>ThreeDViewer</namespace>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "threedviewer",
-  "version": "3.4.0",
+  "version": "3.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "threedviewer",
-      "version": "3.4.0",
+      "version": "3.5.0",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@nextcloud/axios": "^2.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "threedviewer",
-  "version": "3.4.0",
+  "version": "3.5.0",
   "license": "AGPL-3.0-or-later",
   "engines": {
     "node": "^22.0.0",


### PR DESCRIPTION
Minor rather than patch. The viewer is redrawn on a themeable design system: the Theme control now moves the whole viewer rather than only the scene background and grid, every control is a Material Design icon instead of an emoji, and the top bar, tools panel, slicer dialog, performance HUD and the measurement and annotation surfaces follow the design sheet.

Also carries three.js r185, the move to ESLint flat config for `@nextcloud/eslint-config` v9, and three security fixes in the production dependency graph.

## What this changes

Moves the 65 accumulated `[Unreleased]` entries under `[3.5.0]` and opens a fresh `[Unreleased]` section. Nothing else — no code changes ride along.

| | |
| --- | --- |
| `appinfo/info.xml` | 3.4.0 → 3.5.0 |
| `package.json` | 3.4.0 → 3.5.0 |
| `package-lock.json` | both `version` fields |

Entries: 3 added, 12 changed, 49 fixed, 1 security.

## Verification

- `npm ci` clean with the npm this repository declares
- `format:check`, `build` within budget, `lint`, `stylelint` — all pass
- 39 suites, 1294 tests
- `npm audit --omit=dev --audit-level=moderate` — **found 0 vulnerabilities**

## After merge

The tag is what publishes. `release.yml` fires on `v*`, builds the artifact and creates the GitHub release, then `publish-to-appstore` pushes it to the Nextcloud App Store — and that step is `continue-on-error`, so a green release run does not by itself mean the app store received it. Worth confirming the listing separately once the tag lands.
