### PR TITLE
ci: fail the release when the app store did not receive it

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -111,12 +111,28 @@ jobs:
     environment: Prod
 
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.build-and-release.outputs.tag }}
+          persist-credentials: false
+
+      - name: Set up node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      # Deliberately not continue-on-error. It was, and a failed publish then reported
+      # success at the step, the job and the run - which is how v3.5.0 came to be
+      # tagged, built and released with nothing on the store and nothing going red.
       - name: Publish to Nextcloud App Store
         uses: R0Wi/nextcloud-appstore-push-action@v1
-        continue-on-error: true
         with:
           app_name: threedviewer
           appstore_token: ${{ secrets.APPSTORE_TOKEN }}
           app_private_key: ${{ secrets.APP_PRIVATE_KEY }}
           download_url: https://github.com/${{ github.repository }}/releases/download/${{ needs.build-and-release.outputs.tag }}/threedviewer-${{ needs.build-and-release.outputs.tag }}.tar.gz
 
+      # The action above can report success without publishing, so ask the store.
+      - name: Verify the store is serving the release
+        run: node scripts/verify-appstore-release.mjs --tag ${{ needs.build-and-release.outputs.tag }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- The release workflow reported success when nothing was published. The app store step was `continue-on-error`, so a failed publish went green at the step, the job and the run — v3.5.0 was tagged, built and released with nothing on the store and nothing anywhere to say so. That flag is gone, and a step after it asks the store whether it is serving the release, checking the platform range and download URL as well as the version.
+
 ## [3.5.0] - 2026-08-11
 
 The viewer is redrawn on a themeable design system: the Theme control now moves the whole viewer rather than only the scene, every control is a Material Design icon instead of an emoji, and the top bar, tools panel, slicer dialog, performance HUD and the measurement and annotation surfaces follow the design sheet. Also carries three.js r185, the move to ESLint flat config, and the security fixes listed below.

--- a/scripts/appstore-release-lib.mjs
+++ b/scripts/appstore-release-lib.mjs
@@ -1,0 +1,86 @@
+/**
+ * Deciding whether a release actually reached the Nextcloud App Store.
+ *
+ * Kept apart from the fetching so it can be tested against the shapes the store
+ * really returns, the way `pr-ready-lib.mjs` is: the last gate in this repository
+ * that had no tests was wrong twice.
+ */
+
+/**
+ * The store's record of one version of one app.
+ *
+ * @param {object[]} apps - the store index, as `apps.json` returns it
+ * @param {string} appId - the app's store id
+ * @param {string} version - the version to look for
+ * @return {object|null} the release, or null if the app or the version is absent
+ */
+export function findRelease(apps, appId, version) {
+	const app = (apps ?? []).find((a) => a.id === appId)
+	return app?.releases?.find((r) => r.version === version) ?? null
+}
+
+/**
+ * Every version the store lists for an app, newest first as the store orders them.
+ *
+ * @param {object[]} apps - the store index
+ * @param {string} appId - the app's store id
+ * @return {string[]|null} the versions, or null if the app is not listed
+ */
+export function listedVersions(apps, appId) {
+	const app = (apps ?? []).find((a) => a.id === appId)
+	return app ? (app.releases ?? []).map((r) => r.version) : null
+}
+
+/**
+ * Whether the store is serving the release that was just published, and serving it
+ * as the manifest describes it.
+ *
+ * Presence is the check that would have caught v3.5.0. The rest are conditions a
+ * release can be listed under and still be wrong: a platform range narrower than the
+ * manifest's is live and invisible to admins on the versions it drops, and a download
+ * URL for another tag is a listing for a different build.
+ *
+ * @param {object} input - what to check
+ * @param {object[]} input.apps - the store index
+ * @param {string} input.appId - the app's store id
+ * @param {string} input.version - the version just published
+ * @param {string} input.tag - the git tag it was released under
+ * @param {string} input.declaredPlatformSpec - the range built from appinfo/info.xml
+ * @return {{ok: boolean, problems: string[]}} the verdict and every reason for it
+ */
+export function assess({ apps, appId, version, tag, declaredPlatformSpec }) {
+	const problems = []
+	const versions = listedVersions(apps, appId)
+
+	if (versions === null) {
+		return { ok: false, problems: [`the store has no app called "${appId}" — it is not listed at all`] }
+	}
+
+	const release = findRelease(apps, appId, version)
+	if (!release) {
+		problems.push(`the store does not list ${version}. It lists: ${versions.join(', ') || '(nothing)'}`)
+		return { ok: false, problems }
+	}
+
+	if (release.isNightly) {
+		problems.push(`${version} is recorded as a nightly, so no stable instance will offer it`)
+	}
+
+	if (!release.signature) {
+		problems.push(`${version} carries no signature`)
+	}
+
+	if (declaredPlatformSpec && release.rawPlatformVersionSpec !== declaredPlatformSpec) {
+		problems.push(
+			`platform range is "${release.rawPlatformVersionSpec}", `
+			+ `where appinfo/info.xml declares "${declaredPlatformSpec}" — `
+			+ 'the release is live but invisible to the server versions the difference drops',
+		)
+	}
+
+	if (tag && !String(release.download ?? '').includes(`/${tag}/`)) {
+		problems.push(`download URL does not come from ${tag}: ${release.download}`)
+	}
+
+	return { ok: problems.length === 0, problems }
+}

--- a/scripts/verify-appstore-release.mjs
+++ b/scripts/verify-appstore-release.mjs
@@ -1,0 +1,80 @@
+#!/usr/bin/env node
+/**
+ * Ask the Nextcloud App Store whether the release actually arrived.
+ *
+ * `release.yml` publishes through an action whose step is `continue-on-error`, so a
+ * failed publish reports success at every level GitHub shows: the step, the job and
+ * the run. v3.5.0 was tagged, built, released on GitHub and never published, and
+ * nothing anywhere went red. This asks the store directly and fails the job when the
+ * answer is no.
+ *
+ * Usage: node scripts/verify-appstore-release.mjs [--tag v3.5.0] [--timeout 600]
+ *
+ * The store publishes no per-app endpoint, so this downloads the platform index —
+ * about 10 MB — once per attempt. Indexing is not instant after a push, hence the
+ * poll rather than a single look.
+ */
+import { readFileSync } from 'node:fs'
+import { assess } from './appstore-release-lib.mjs'
+
+const APP_ID = 'threedviewer'
+
+const arg = (name, fallback) => {
+	const i = process.argv.indexOf(`--${name}`)
+	return i === -1 ? fallback : process.argv[i + 1]
+}
+
+/**
+ * The version and supported server range this build declares.
+ *
+ * @return {{version: string, min: string, max: string, spec: string}} the manifest's claims
+ */
+function manifest() {
+	const xml = readFileSync(new URL('../appinfo/info.xml', import.meta.url), 'utf8')
+	const version = /<version>([^<]+)<\/version>/.exec(xml)?.[1]
+	const platform = /<nextcloud\s+min-version="([^"]+)"\s+max-version="([^"]+)"/.exec(xml)
+	if (!version || !platform) throw new Error('could not read version and platform range from appinfo/info.xml')
+	return { version, min: platform[1], max: platform[2], spec: `>=${platform[1]} <=${platform[2]}` }
+}
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms))
+
+const { version, min, spec } = manifest()
+const tag = arg('tag', `v${version}`)
+const timeout = Number(arg('timeout', '600')) * 1000
+const index = `https://apps.nextcloud.com/api/v1/platform/${min}.0.0/apps.json`
+
+console.log(`[appstore] looking for ${APP_ID} ${version} (${tag}), expecting platform "${spec}"`)
+
+const startedAt = Date.now()
+let attempt = 0
+let last = { ok: false, problems: ['no attempt completed'] }
+
+while (Date.now() - startedAt < timeout) {
+	attempt++
+	try {
+		const res = await fetch(index, { headers: { Accept: 'application/json' } })
+		if (!res.ok) throw new Error(`store returned HTTP ${res.status}`)
+		last = assess({ apps: await res.json(), appId: APP_ID, version, tag, declaredPlatformSpec: spec })
+		if (last.ok) {
+			console.log(`[appstore] OK — ${version} is published and matches the manifest (attempt ${attempt})`)
+			process.exit(0)
+		}
+	} catch (error) {
+		last = { ok: false, problems: [`could not read the store index: ${error.message}`] }
+	}
+
+	const waited = Math.round((Date.now() - startedAt) / 1000)
+	console.log(`[appstore] attempt ${attempt} at ${waited}s: ${last.problems.join('; ')}`)
+	if (Date.now() - startedAt + 30000 >= timeout) break
+	await sleep(30000)
+}
+
+console.error('')
+console.error(`[appstore] FAILED after ${Math.round((Date.now() - startedAt) / 1000)}s:`)
+for (const problem of last.problems) console.error(`  - ${problem}`)
+console.error('')
+console.error('The GitHub release is unaffected and still stands. Publishing is what did not')
+console.error('happen, so nothing needs reverting - the artifact can be pushed again, or')
+console.error(`uploaded by hand from the ${tag} release page.`)
+process.exit(1)

--- a/tests/unit/appstoreRelease.test.js
+++ b/tests/unit/appstoreRelease.test.js
@@ -1,0 +1,108 @@
+/**
+ * The app store publish check.
+ *
+ * `release.yml` pushes the built artifact to the Nextcloud App Store through a step
+ * marked `continue-on-error`, so the step reported success while publishing nothing:
+ * v3.5.0 was tagged, released on GitHub, and absent from the store, with every job,
+ * step and workflow run green. The only way to find out was to ask the store.
+ *
+ * This is that question, asked in code. It checks more than presence, because a
+ * release can be listed and still be wrong in ways nobody would look for: a platform
+ * range that does not match the manifest is live and invisible to a slice of admins,
+ * and a download URL pointing at another tag is a listing for a different build.
+ */
+import { assess, findRelease } from '../../scripts/appstore-release-lib.mjs'
+
+/** A release as the store's apps.json returns it. */
+const release = (over = {}) => ({
+	version: '3.5.0',
+	isNightly: false,
+	signature: 'AAAA',
+	rawPlatformVersionSpec: '>=31 <=34',
+	download: 'https://github.com/maz1987in/3Dviewer-Nextcloud/releases/download/v3.5.0/threedviewer-v3.5.0.tar.gz',
+	...over,
+})
+
+/** The store index, as a list of apps. */
+const store = (releases) => [
+	{ id: 'someotherapp', releases: [{ version: '1.0.0' }] },
+	{ id: 'threedviewer', releases },
+]
+
+const subject = (over = {}) => ({
+	apps: store([release(), { version: '3.4.0' }]),
+	appId: 'threedviewer',
+	version: '3.5.0',
+	tag: 'v3.5.0',
+	declaredPlatformSpec: '>=31 <=34',
+	...over,
+})
+
+describe('findRelease', () => {
+	it('finds the version among an app\'s releases', () => {
+		expect(findRelease(store([release()]), 'threedviewer', '3.5.0').version).toBe('3.5.0')
+	})
+
+	it('returns null when the app is not in the index', () => {
+		expect(findRelease(store([release()]), 'nosuchapp', '3.5.0')).toBeNull()
+	})
+
+	it('returns null when the app is listed without that version', () => {
+		expect(findRelease(store([{ version: '3.4.0' }]), 'threedviewer', '3.5.0')).toBeNull()
+	})
+})
+
+describe('assess', () => {
+	it('passes a release that is listed and correct', () => {
+		const { ok, problems } = assess(subject())
+		expect(problems).toEqual([])
+		expect(ok).toBe(true)
+	})
+
+	it('fails when the version is absent — the case that shipped', () => {
+		const { ok, problems } = assess(subject({ apps: store([{ version: '3.4.0' }]) }))
+		expect(ok).toBe(false)
+		expect(problems.join(' ')).toMatch(/3\.5\.0/)
+		expect(problems.join(' ')).toMatch(/3\.4\.0/)
+	})
+
+	it('fails when the app is not listed at all', () => {
+		const { ok, problems } = assess(subject({ apps: [{ id: 'someotherapp', releases: [] }] }))
+		expect(ok).toBe(false)
+		expect(problems.join(' ')).toMatch(/not listed/i)
+	})
+
+	it('fails a platform range that does not match the manifest', () => {
+		const { ok, problems } = assess(subject({
+			apps: store([release({ rawPlatformVersionSpec: '>=31 <=33' })]),
+		}))
+		expect(ok).toBe(false)
+		expect(problems.join(' ')).toMatch(/>=31 <=33/)
+	})
+
+	it('fails a download URL pointing at another tag', () => {
+		const { ok, problems } = assess(subject({
+			apps: store([release({ download: 'https://example.invalid/releases/download/v3.4.0/x.tar.gz' })]),
+		}))
+		expect(ok).toBe(false)
+		expect(problems.join(' ')).toMatch(/v3\.5\.0/)
+	})
+
+	it('fails a release the store recorded as a nightly', () => {
+		const { ok } = assess(subject({ apps: store([release({ isNightly: true })]) }))
+		expect(ok).toBe(false)
+	})
+
+	it('fails a release with no signature', () => {
+		const { ok, problems } = assess(subject({ apps: store([release({ signature: null })]) }))
+		expect(ok).toBe(false)
+		expect(problems.join(' ')).toMatch(/signature/i)
+	})
+
+	it('reports every problem at once rather than the first', () => {
+		const { problems } = assess(subject({
+			apps: store([release({ isNightly: true, signature: null, rawPlatformVersionSpec: 'x' })]),
+		}))
+		expect(problems.length).toBeGreaterThanOrEqual(3)
+	})
+})


### PR DESCRIPTION
v3.5.0 was tagged, built, released on GitHub — and never reached the Nextcloud App Store. Every level GitHub shows was green: the workflow run, both jobs, and the publish step itself.

That is not a reporting quirk. `publish-to-appstore` carried `continue-on-error: true`, which swallowed the failure at the *step*, so nothing anywhere in GitHub recorded that publishing did not happen. The only way to discover it was to ask the store, and the only reason anyone did was that the check had been called out in advance.

## What changes

**`continue-on-error: true` is removed.** A failed publish now fails the job. The GitHub release is created in a separate job that has already finished by then, so nothing about the release itself is at risk — only the publish goes red, which is exactly what should have happened.

**A step after the publish asks the store.** The action can report success without publishing, so its word is not taken for it.

The check is not just presence. A release can be listed and still be wrong in ways nobody would look for:

| checked | why |
| --- | --- |
| the version is listed | the failure that shipped |
| platform range matches `appinfo/info.xml` | a narrower range is live and **invisible** to the server versions it drops |
| download URL comes from this tag | a URL from another tag is a listing for a different build |
| not recorded as a nightly | no stable instance would offer it |
| a signature is present | |

The store publishes no per-app endpoint, so this downloads the ~10 MB platform index, once per attempt, polling at 30-second intervals for up to ten minutes — indexing is not instant after a push.

## Structure

The deciding logic is `scripts/appstore-release-lib.mjs`, separate from the fetching and covered by 11 tests, following `pr-ready-lib.mjs`. That split exists for a reason recorded in this repository: the last gate that shipped without tests was wrong twice, and a gate that cries wolf is the one people learn to ignore.

## Verified both ways against the live store

Passing, on the release that is actually published:

```
[appstore] looking for threedviewer 3.5.0 (v3.5.0), expecting platform ">=31 <=34"
[appstore] OK — 3.5.0 is published and matches the manifest (attempt 1)
exit: 0
```

Failing, on a version that was never published — and saying what the store does have:

```
[appstore] FAILED after 19s:
  - the store does not list 9.9.9. It lists: 3.5.0, 3.4.0, 3.3.2, 3.3.1, …
exit: 1
```

The failure output also states that the GitHub release is unaffected and nothing needs reverting, because the instinct on a red release job is to assume something has to be undone.
